### PR TITLE
Make bigdecimal ruby 27 compatible

### DIFF
--- a/lib/arithmetic/nodes.rb
+++ b/lib/arithmetic/nodes.rb
@@ -1,7 +1,7 @@
-module Arithmetic 
+module Arithmetic
   class OperandNode
     attr_accessor :operand
-   
+
     def initialize(operand)
       @operand = operand
     end
@@ -9,7 +9,7 @@ module Arithmetic
     def to_s(visitor, na=nil)
       visitor.call(@operand)
     end
-   
+
     def eval
       if has_dangling_decimal_point?
         BigDecimal(@operand + "0")
@@ -27,12 +27,12 @@ module Arithmetic
 
   class OperatorNode
     attr_accessor :operator, :operands
-   
+
     def initialize(operator, operands)
       @operator = operator
       @operands = operands
     end
-   
+
     def to_s(visitor, top=true)
       strs = @operands.map {|o| o.to_s(visitor, false) }
 
@@ -44,7 +44,7 @@ module Arithmetic
         result
       end
     end
-   
+
     def eval
       @operator.eval(*@operands.map(&:eval))
     end

--- a/lib/arithmetic/nodes.rb
+++ b/lib/arithmetic/nodes.rb
@@ -12,9 +12,9 @@ module Arithmetic
    
     def eval
       if has_dangling_decimal_point?
-        BigDecimal.new(@operand + "0")
+        BigDecimal(@operand + "0")
       else
-        BigDecimal.new(@operand)
+        BigDecimal(@operand)
       end
     end
 

--- a/lib/arithmetic/version.rb
+++ b/lib/arithmetic/version.rb
@@ -1,3 +1,3 @@
 module Arithmetic
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/arithmetic_spec.rb
+++ b/spec/arithmetic_spec.rb
@@ -2,47 +2,47 @@ require 'spec_helper'
 
 describe Arithmetic do
   it "evaluates simple expressions" do
-    test_eval("2").should == 2.0
+    expect(test_eval("2")).to be == 2.0
   end
 
   it "evaluates addition" do
-    test_eval("2 + 2").should == 4.0
+    expect(test_eval("2 + 2")).to be == 4.0
   end
 
   it "evaluates subtraction" do
-    test_eval("2.1 - 2").should == 0.1
+    expect(test_eval("2.1 - 2")).to be == 0.1
   end
 
   it "handles negative numbers" do
-    test_eval("3--2").should == 5
+    expect(test_eval("3--2")).to be == 5
   end
 
   it "handles negative numbers with parens" do
-    test_eval("-(3+2)").should == -5
+    expect(test_eval("-(3+2)")).to be == -5
   end
 
   it "handles leading minus signs" do
-    test_eval("-3+2").should == -1
+    expect(test_eval("-3+2")).to be == -1
   end
 
   it "has unary minus take precedence over multiplication" do
-    test_eval("-3 * -2").should == 6
+    expect(test_eval("-3 * -2")).to be == 6
   end
 
   it "evaluates division" do
-    test_eval("10.5 / 5").should == 2.1
+    expect(test_eval("10.5 / 5")).to be == 2.1
   end
 
   it "evaluates multiplication" do
-    test_eval("2 * 3.1").should == 6.2
+    expect(test_eval("2 * 3.1")).to be == 6.2
   end
 
   it "evaluates parens" do
-    test_eval("2 * (2.1 + 1)").should == 6.2
+    expect(test_eval("2 * (2.1 + 1)")).to be == 6.2
   end
 
   it "evaluates regardless of whitespace" do
-    test_eval("2*(1+\t1)").should == 4
+    expect(test_eval("2*(1+\t1)")).to be == 4
   end
 
   it "evaluates order of operations" do
@@ -50,27 +50,27 @@ describe Arithmetic do
   end
 
   it "evaluates multiple levels of parens" do
-    test_eval("2*(1/(1+3))").should == 0.5
+    expect(test_eval("2*(1/(1+3))")).to be == 0.5
   end
 
   it "formats the expression" do
-    test_to_s("   -1+\n    2*     \t3").should == '-1 + (2 * 3)'
+    expect(test_to_s("   -1+\n    2*     \t3")).to be == '-1 + (2 * 3)'
   end
 
   it "formats the expression using a custom visitor" do
-    test_to_s("-1 + 2 * 3", ->(n) { "x#{n}x" }).should == 'x-xx1x x+x x(xx2x x*x x3xx)x'
+    expect(test_to_s("-1 + 2 * 3", ->(n) { "x#{n}x" })).to be == 'x-xx1x x+x x(xx2x x*x x3xx)x'
   end
 
   it "handles ridiculous precision" do
-    test_eval("1.111111111111111111111111111111111111111111 + 2").should == BigDecimal('3.111111111111111111111111111111111111111111')
+    expect(test_eval("1.111111111111111111111111111111111111111111 + 2")).to be == BigDecimal('3.111111111111111111111111111111111111111111')
   end
 
   it "handles simple numbers" do
-    test_eval(2).should == 2
+    expect(test_eval(2)).to be == 2
   end
 
   it "handles dangling decimal points" do
-    test_eval("0.").should == 0
+    expect(test_eval("0.")).to be == 0
   end
 
   context "invalid expressions" do

--- a/spec/arithmetic_spec.rb
+++ b/spec/arithmetic_spec.rb
@@ -62,7 +62,7 @@ describe Arithmetic do
   end
 
   it "handles ridiculous precision" do
-    test_eval("1.111111111111111111111111111111111111111111 + 2").should == BigDecimal.new('3.111111111111111111111111111111111111111111')
+    test_eval("1.111111111111111111111111111111111111111111 + 2").should == BigDecimal('3.111111111111111111111111111111111111111111')
   end
 
   it "handles simple numbers" do


### PR DESCRIPTION
* Use `BigDecimal()` instead of `BigDecimal.new`, which was removed in Ruby 2.7
* small QoL updates:
  * remove leading space on blank lines and trailing spaces
  * change `.should` syntax to `expect`